### PR TITLE
Fix/trigger sent on reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.5.1](https://https///compare/v2.5.0...v2.5.1) (2021-12-14)
+
+
+### Bug Fixes
+
+* remove trigger of register if attempting reconnection ([bc328e0](https://https///commit/bc328e0f5168c2c019edc4a23c9b47991e16383d))
+
 ## [2.5.0](https://https///compare/v1.7.2...v2.5.0) (2021-12-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "push-webchat",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "push-webchat",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Chat web widget for React apps and Push chatbots",
   "module": "module/index.js",
   "main": "lib/index.js",

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -483,6 +483,9 @@ class Widget extends Component {
         dispatch(initialize());
       }
     } else {
+      if (!sendInitPayload) {
+        delete options.trigger;
+      }
       websocket.send(JSON.stringify(options));
       // If this is an existing session, it's possible we changed pages and want to send a
       // user message when we land.


### PR DESCRIPTION
**Proposed changes**:
- If the webchat is attempting a reconnection, do not send trigger parameter on register payload.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [X] updated the changelog
