### PR TITLE
Fix: WebChat classes box-sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.5.2](https://https///compare/v2.5.1...v2.5.2) (2022-01-17)
+
+
+### Bug Fixes
+
+* overwrite box-sizing for all webchat classes ([044fbbc](https://https///commit/044fbbcc03f863296231b1f0fafdae624794ba71))
+
 ### [2.5.1](https://https///compare/v2.5.0...v2.5.1) (2021-12-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "push-webchat",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "push-webchat",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Chat web widget for React apps and Push chatbots",
   "module": "module/index.js",
   "main": "lib/index.js",

--- a/src/components/Widget/style.scss
+++ b/src/components/Widget/style.scss
@@ -1,6 +1,10 @@
 @import "animation.scss";
 @import "common.scss";
 
+*[class^="push-"] {
+  box-sizing: unset !important;
+}
+
 .push-widget-container {
   bottom: 0;
   display: flex;


### PR DESCRIPTION
**Proposed changes**:
- Apply `box-sizing: unset !important` to all `push-` classes to prevent the common:
```css
* {
 box-sizing: border-box;
}
```
to affect the webchat CSS behavior.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [X] updated the changelog
